### PR TITLE
error: Type mismatch

### DIFF
--- a/src/birl.gleam
+++ b/src/birl.gleam
@@ -8,7 +8,7 @@ import gleam/order
 import gleam/regexp
 import gleam/result
 import gleam/string
-
+import gleam/yielder
 import birl/duration
 import birl/zones
 
@@ -1153,7 +1153,7 @@ pub fn range(
   from a: Time,
   to b: option.Option(Time),
   step s: duration.Duration,
-) -> iterator.Iterator(Time) {
+) -> yielder.Yielder(Time) {
   let assert Ok(range) = case b {
     option.Some(b) ->
       ranger.create(


### PR DESCRIPTION
```
error: Type mismatch
     ┌─ C:\coding\projects\realtime_chat\build\packages\birl\src\birl.gleam:1163:3
     │
1163 │   range
     │   ^^^^^

The type of this returned value doesn't match the return type
annotation of this function.

Expected type:

    iterator.Iterator(Time)

Found type:

    yielder.Yielder(Time)

```

this wouldn't let me compile my project on windows 11 64bit 
name = "birl"
version = "1.7.1"